### PR TITLE
fix: resolve empty error box when running pyne without arguments

### DIFF
--- a/src/pynecore/cli/app.py
+++ b/src/pynecore/cli/app.py
@@ -12,7 +12,7 @@ except ImportError:
 __all__ = ["app", "app_state"]
 
 app = typer.Typer(
-    no_args_is_help=True,
+    invoke_without_command=True,
     context_settings={"help_option_names": ["-h", "--help"]},
     rich_markup_mode="rich",
 )

--- a/src/pynecore/cli/commands/__init__.py
+++ b/src/pynecore/cli/commands/__init__.py
@@ -34,10 +34,13 @@ def setup(
     """
     Pyne Command Line Interface
     """
-    if ctx.resilient_parsing or ctx.invoked_subcommand is None:
+    if ctx.resilient_parsing:
         return
-    if any(arg in ('-h', '--help') for arg in sys.argv[1:]):
-        return
+    
+    # If no subcommand is provided, show complete help like --help
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+        raise typer.Exit(0)
 
     typer.echo("")
 


### PR DESCRIPTION
Fixes #2: pyne command should show no error when there's no command or parameter

- Added invoke_without_command=True to typer app configuration
- Updated setup callback to show help and exit cleanly when no subcommand provided
- Removed no_args_is_help=True in favor of explicit callback handling
- Now pyne without arguments behaves identically to pyne --help with exit code 0

Tested all CLI commands to ensure no regressions introduced.