### PR TITLE
Fix/order trailing margin fees

### DIFF
--- a/src/pynecore/core/script_runner.py
+++ b/src/pynecore/core/script_runner.py
@@ -165,7 +165,7 @@ class ScriptRunner:
 
     __slots__ = ('script_module', 'script', 'ohlcv_iter', 'syminfo', 'update_syminfo_every_run',
                  'bar_index', 'tz', 'plot_writer', 'strat_writer', 'trades_writer', 'last_bar_index',
-                 'equity_curve', 'first_price', 'last_price')
+                 'equity_curve', 'first_price', 'last_price', 'prev_close_price')
 
     def __init__(self, script_path: Path, ohlcv_iter: Iterable[OHLCV], syminfo: SymInfo, *,
                  plot_path: Path | None = None, strat_path: Path | None = None,
@@ -210,6 +210,7 @@ class ScriptRunner:
         self.equity_curve: list[float] = []
         self.first_price: float | None = None
         self.last_price: float | None = None
+        self.prev_close_price: float | None = None
 
         self.plot_writer = CSVWriter(
             plot_path, float_fmt=f".8g"
@@ -382,6 +383,8 @@ class ScriptRunner:
 
                 # Update bar index
                 self.bar_index += 1
+                # Update prev_close_price
+                position.prev_c = self.prev_close_price = lib.close  # type: ignore
                 # It is no longer the first bar
                 barstate.isfirst = False
 

--- a/src/pynecore/lib/strategy/__init__.py
+++ b/src/pynecore/lib/strategy/__init__.py
@@ -627,7 +627,7 @@ class Position:
         if ((order.order_type == _order_type_close and order.size > 0) or (
                 order.order_type == _order_type_entry and order.size > 0)) and order.stop <= self.h:
             p = max(order.stop, self.o)
-            self.fill_order(order, order.stop, p, self.l)
+            self.fill_order(order, p, p, self.l)
 
     def _check_high(self, order: Order):
         """ Check high limit """
@@ -635,7 +635,7 @@ class Position:
             if ((order.order_type == _order_type_close and order.size < 0) or (
                     order.order_type == _order_type_entry and order.size < 0)) and order.limit <= self.h:
                 p = max(order.limit, self.o)
-                self.fill_order(order, order.limit, p, self.l)
+                self.fill_order(order, p, p, self.l)
 
         # Update trailing stop
         if order.trail_price is not None and order.sign < 0:
@@ -645,7 +645,7 @@ class Position:
             # Update stop if trailing price has been triggered
             if order.trail_triggered:
                 offset_price = syminfo.mintick * order.trail_offset
-                order.stop = max(lib.math.round_to_mintick(order.trail_price - offset_price), order.stop)  # type: ignore
+                order.stop = max(lib.math.round_to_mintick(self.h - offset_price), order.stop)  # type: ignore
 
     def _check_low_stop(self, order: Order):
         """ Check low stop """
@@ -654,7 +654,7 @@ class Position:
         if ((order.order_type == _order_type_close and order.size < 0) or (
                 order.order_type == _order_type_entry and order.size < 0)) and order.stop >= self.l:
             p = min(self.o, order.stop)
-            self.fill_order(order, order.stop, self.h, p)
+            self.fill_order(order, p, self.h, p)
 
     def _check_low(self, order: Order):
         """ Check low limit """
@@ -662,7 +662,7 @@ class Position:
             if ((order.order_type == _order_type_close and order.size > 0) or (
                     order.order_type == _order_type_entry and order.size > 0)) and order.limit >= self.l:
                 p = min(self.o, order.limit)
-                self.fill_order(order, order.limit, self.h, p)
+                self.fill_order(order, p, self.h, p)
 
         # Update trailing stop
         if order.trail_price is not None and order.sign > 0:
@@ -672,7 +672,7 @@ class Position:
             # Update stop if trailing price has been triggered
             if order.trail_triggered:
                 offset_price = syminfo.mintick * order.trail_offset
-                order.stop = min(lib.math.round_to_mintick(order.trail_price + offset_price), order.stop)  # type: ignore
+                order.stop = min(lib.math.round_to_mintick(self.l + offset_price), order.stop)  # type: ignore
 
     def _check_close(self, order: Order, ohlcv: bool):
         """ Check close price if trailing stop is triggered """

--- a/src/pynecore/lib/strategy/__init__.py
+++ b/src/pynecore/lib/strategy/__init__.py
@@ -236,6 +236,7 @@ class Position:
     size: float = 0.0
     sign: float = 0.0
     avg_price: float = 0.0
+    prev_c: float = 0.0
 
     cum_profit: float | NA[float] = 0.0
 
@@ -691,6 +692,7 @@ class Position:
         self.h = round_to_mintick(lib.high)
         self.l = round_to_mintick(lib.low)
         self.c = round_to_mintick(lib.close)
+        self.prev_c = round_to_mintick(self.prev_c)
 
         # Get script reference for slippage
         script = lib._script
@@ -735,13 +737,13 @@ class Position:
             # Market orders
             if order.is_market_order:
                 # Apply slippage to market orders
-                fill_price = self.o
+                fill_price = self.prev_c
                 if script.slippage > 0:
                     # Slippage is in ticks, always adverse to trade direction
                     # For long orders (buying), slippage increases the price
                     # For short orders (selling), slippage decreases the price
                     slippage_amount = syminfo.mintick * script.slippage * order.sign
-                    fill_price = self.o + slippage_amount
+                    fill_price = self.prev_c + slippage_amount
 
                 # open → high → low → close
                 if ohlc:

--- a/src/pynecore/lib/strategy/__init__.py
+++ b/src/pynecore/lib/strategy/__init__.py
@@ -758,7 +758,7 @@ class Position:
                     self._check_low(order)
 
         # 2nd round of process open orders
-        for order in list(self.entry_orders.values()) + list(self.exit_orders.values()):
+        for order in list(chain(self.entry_orders.values(), self.exit_orders.values())):
             # For exit orders, calculate limit/stop from entry price if not already done
             if order.order_type == _order_type_close and order.order_id:
                 # Only recalculate if not already set in first round
@@ -1125,7 +1125,8 @@ def entry(id: str, direction: direction.Direction, qty: int | float | NA[float] 
 
     # We need a signed size instead of qty, the sign is the direction
     direction_sign: float = (-1.0 if direction == short else 1.0)
-    size = qty * direction_sign
+    margin: float = (script.margin_short if direction == short else script.margin_long)
+    size = qty * direction_sign / margin
     sign = 0.0 if size == 0.0 else 1.0 if size > 0.0 else -1.0
 
     # Check pyramiding limit (only for same direction trades)


### PR DESCRIPTION
### Summary
This PR fixes and improves the order handling logic in the trading engine. The following updates are included:

- Adjusted order prices for fill orders to ensure accurate execution.
- Offset the closing price starting point for trailing stops.
- Partially omitted NA values in judgments to prevent incorrect calculations.
- Added margin calculations to ensure correct order sizing.
- Corrected percentage fee statistics for more accurate reporting.
- Fixed open price for market orders: previously the current bar's open price was used, now it uses the previous bar's close price for consistency.

### Impact
- Trading logic is more accurate and robust.
- Trailing stops now calculate correctly.
- Order sizing considers margin and fees properly.
- Historical NA values will not break calculations.

### Notes
- No breaking changes to existing API.
- All tests should pass as before, with improved accuracy for order-related calculations.
