### PR TITLE
docs: fix 1 typo(s) in docs

### DIFF
--- a/docs/reference/lib/str.md
+++ b/docs/reference/lib/str.md
@@ -198,7 +198,7 @@ Returns a new string with the Nth occurrence of the target substring replaced by
 | source | str | The string to modify |
 | target | str | The substring to replace |
 | replacement | str | The replacement string |
-| occurence | int | Which occurrence to replace (0-based), default 0 |
+| occurrence | int | Which occurrence to replace (0-based), default 0 |
 
 **Returns:** `str`
 


### PR DESCRIPTION
## Summary

Fixed 1 typo(s) found in documentation files while reading the docs.

## Changes

- `docs/reference/lib/str.md` L201: `occurence` → `occurrence`

## Type of change

- [x] Documentation fix (typo/spelling only)

## Checklist

- [x] I have read the contributing guidelines
- [x] My changes follow the existing documentation style
- [x] No code changes — documentation only

---

*Found via automated spell-check. Please review each fix carefully. Happy to adjust if any correction doesn't fit the intended meaning.*
